### PR TITLE
Corrected ordering of path loading / definition of OutputPathModels in CNN.py

### DIFF
--- a/CNN.py
+++ b/CNN.py
@@ -211,9 +211,9 @@ class EarlyStoppingByLossVal(keras.callbacks.Callback):
 
 def main():
     print("START")
+    loadParametersFromFile("PARAMETERS_CNN.txt")
     if not os.path.exists(OutputPathModels):
         os.makedirs(OutputPathModels)
-    loadParametersFromFile("PARAMETERS_CNN.txt")
     #callback=EarlyStopping(monitor='val_acc', min_delta=0, patience=0, verbose=0, mode='auto', baseline=None)
     callback=EarlyStoppingByLossVal(monitor='val_acc', value=0.975, verbose=1, lower=False)
     print("Parameters loaded")


### PR DESCRIPTION
Fix for #14 